### PR TITLE
Use Distribution._distr_parameters_for_repr to obtain parameter names

### DIFF
--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -6,7 +6,12 @@ import theano
 import theano.tensor as tt
 
 from tests.utils import simulate_poiszero_hmm
-from pymc3_hmm.distributions import PoissonZeroProcess, HMMStateSeq, SwitchingProcess
+from pymc3_hmm.distributions import (
+    PoissonZeroProcess,
+    HMMStateSeq,
+    SwitchingProcess,
+    distribution_subset_args,
+)
 
 
 def test_HMMStateSeq_random():
@@ -448,7 +453,47 @@ def test_SwitchingProcess():
 
 
 def test_subset_args():
+
+    test_dist = pm.Constant.dist(c=np.r_[0.1, 1.2, 2.3])
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
+    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
+
+    test_point = {"c": np.r_[2.0, 3.0, 4.0]}
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
+    assert np.array_equal(res[0], np.r_[2.0, 4.0])
+
+    test_dist = pm.Normal.dist(mu=np.r_[0.1, 1.2, 2.3], sigma=np.r_[10.0])
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
+    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
+    assert np.array_equal(res[1].eval(), np.r_[10.0, 10.0])
+
+    test_point = {"mu": np.r_[2.0, 3.0, 4.0], "sigma": np.r_[20.0, 30.0, 40.0]}
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
+    assert np.array_equal(res[0], np.r_[2.0, 4.0])
+    assert np.array_equal(res[1], np.r_[20.0, 40.0])
+
+    test_dist = pm.Poisson.dist(mu=np.r_[0.1, 1.2, 2.3])
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
+    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
+
+    test_point = {"mu": np.r_[2.0, 3.0, 4.0]}
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
+    assert np.array_equal(res[0], np.r_[2.0, 4.0])
+
     test_dist = pm.NegativeBinomial.dist(mu=np.r_[0.1, 1.2, 2.3], alpha=2)
-    res = test_dist.subset_args(shape=[3], idx=np.r_[0, 2])
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
     assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
     assert np.array_equal(res[1].eval(), np.r_[2.0, 2.0])
+
+    test_point = {"mu": np.r_[2.0, 3.0, 4.0], "alpha": np.r_[10, 11, 12]}
+    test_idx = np.r_[0, 2]
+    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
+    assert np.array_equal(res[0], np.r_[2.0, 4.0])
+    assert np.array_equal(res[1], np.r_[10, 12])


### PR DESCRIPTION
Instead of patching `Distribution`s, this PR makes `distribution_subset_args` use `Distribution._distr_parameters_for_repr` as a means of obtaining the parameters to be sliced/subsetted.

This still isn't a particularly "good" approach, because it doesn't give only the essential parameters, but it's better than patching.